### PR TITLE
Add text language selection

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
     "python.formatting.provider": "yapf",
+    "python.pythonPath": "/Users/xissysnd/dev/taehoio/youtube2notion/.venv/bin/python",
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
 {
     "python.formatting.provider": "yapf",
-    "python.pythonPath": "/Users/xissysnd/dev/taehoio/youtube2notion/.venv/bin/python",
 }

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ docker run --rm -it taehoio/youtube2notion youtube2notion.py
 #### Run CLI with arguments
 
 ```sh
-docker run --rm -it taehoio/youtube2notion youtube2notion.py YOUTUBE_VIDEO_ID -t NOTION_TOKEN_V2 -p NOTION_PAGE_ID
+docker run --rm -it taehoio/youtube2notion youtube2notion.py YOUTUBE_VIDEO_ID -t NOTION_TOKEN_V2 -p NOTION_PAGE_ID -l TEXT_LANGUAGE
 ```
 
 ### API server
@@ -64,6 +64,7 @@ curl --location --request POST 'http://localhost:5000/upload' \
 --data-raw '{
     "video_id": "YOUTUBE_VIDEO_ID",
     "notion_token_v2": "NOTION_TOKEN_V2",
-    "notion_page_url": "NOTION_PAGE_ID"
+    "notion_page_url": "NOTION_PAGE_ID",
+    "text_language": "TEXT_LANGUAGE"
 }'
 ```

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ docker run --rm -it taehoio/youtube2notion youtube2notion.py
 #### Run CLI with arguments
 
 ```sh
-docker run --rm -it taehoio/youtube2notion youtube2notion.py YOUTUBE_VIDEO_ID -t NOTION_TOKEN_V2 -p NOTION_PAGE_ID -l TEXT_LANGUAGE
+docker run --rm -it taehoio/youtube2notion youtube2notion.py YOUTUBE_VIDEO_ID -t NOTION_TOKEN_V2 -p NOTION_PAGE_URL -l SUBTITLE_LANGUAGE
 ```
 
 ### API server
@@ -64,7 +64,7 @@ curl --location --request POST 'http://localhost:5000/upload' \
 --data-raw '{
     "video_id": "YOUTUBE_VIDEO_ID",
     "notion_token_v2": "NOTION_TOKEN_V2",
-    "notion_page_url": "NOTION_PAGE_ID",
-    "text_language": "TEXT_LANGUAGE"
+    "notion_page_url": "NOTION_PAGE_URL",
+    "subtitle_language": "SUBTITLE_LANGUAGE"
 }'
 ```

--- a/app.py
+++ b/app.py
@@ -31,7 +31,7 @@ def upload():
         output_dir=output_dir,
         notion_token_v2=notion_token_v2,
         notion_page_url=notion_page_url,
-        text_language=text_language)
+        subtitle_language=subtitle_language)
 
     try:
         y2n.execute()

--- a/app.py
+++ b/app.py
@@ -19,7 +19,7 @@ def upload():
     video_id = req.get('video_id')
     notion_token_v2 = req.get('notion_token_v2')
     notion_page_url = req.get('notion_page_url')
-    text_language = req.get('text_language')
+    subtitle_language = req.get('subtitle_language')
 
     if not video_id:
         return {'msg': 'invalid video_id'}, 400

--- a/app.py
+++ b/app.py
@@ -19,6 +19,7 @@ def upload():
     video_id = req.get('video_id')
     notion_token_v2 = req.get('notion_token_v2')
     notion_page_url = req.get('notion_page_url')
+    text_language = req.get('text_language')
 
     if not video_id:
         return {'msg': 'invalid video_id'}, 400
@@ -29,7 +30,8 @@ def upload():
         video_id=video_id,
         output_dir=output_dir,
         notion_token_v2=notion_token_v2,
-        notion_page_url=notion_page_url)
+        notion_page_url=notion_page_url,
+        text_language=text_language)
 
     try:
         y2n.execute()

--- a/tests/youtube2notion/test_youtube_subtitle.py
+++ b/tests/youtube2notion/test_youtube_subtitle.py
@@ -21,12 +21,10 @@ class TestYoutubeSubtitle(unittest.TestCase):
     def test_get_subtitle_with_specific_language(self):
         self.assertIsNotNone(
             YoutubeSubtitle.get_subtitle_elements(self.video_id, ['ko', 'en']))
+        self.assertIsNotNone(
+            YoutubeSubtitle.get_subtitle_elements(self.video_id,
+                                                  ['aa', 'bb', 'en']))
 
     def test_get_subtitle_with_unknown_language_codes_exception(self):
         with self.assertRaises(NoTranscriptFound):
             YoutubeSubtitle.get_subtitle_elements(self.video_id, ['aa', 'bb'])
-
-    def test_get_subtitle_with_specific_language(self):
-        self.assertIsNotNone(
-            YoutubeSubtitle.get_subtitle_elements(self.video_id,
-                                                  ['aa', 'bb', 'en']))

--- a/tests/youtube2notion/test_youtube_subtitle.py
+++ b/tests/youtube2notion/test_youtube_subtitle.py
@@ -1,6 +1,6 @@
 import unittest
 from youtube2notion.youtube_subtitle import YoutubeSubtitle
-from youtube_transcript_api._errors import TranslationLanguageNotAvailable
+from youtube_transcript_api._errors import NoTranscriptFound
 
 
 class TestYoutubeSubtitle(unittest.TestCase):
@@ -12,7 +12,7 @@ class TestYoutubeSubtitle(unittest.TestCase):
             category=ResourceWarning,
             message="unclosed.*<ssl.SSLSocket.*>")
 
-        self.video_id = 'Kc_cvAXCs4Y'
+        self.video_id = '5oNcoj4G0xc'
 
     def test_get_subtitle_elements(self):
         self.assertIsNotNone(
@@ -22,6 +22,11 @@ class TestYoutubeSubtitle(unittest.TestCase):
         self.assertIsNotNone(
             YoutubeSubtitle.get_subtitle_elements(self.video_id, ['ko', 'en']))
 
-    def test_get_subtitle_with_unknown_language_exception(self):
-        with self.assertRaises(TranslationLanguageNotAvailable):
+    def test_get_subtitle_with_unknown_language_codes_exception(self):
+        with self.assertRaises(NoTranscriptFound):
             YoutubeSubtitle.get_subtitle_elements(self.video_id, ['aa', 'bb'])
+
+    def test_get_subtitle_with_specific_language(self):
+        self.assertIsNotNone(
+            YoutubeSubtitle.get_subtitle_elements(self.video_id,
+                                                  ['aa', 'bb', 'en']))

--- a/tests/youtube2notion/test_youtube_subtitle.py
+++ b/tests/youtube2notion/test_youtube_subtitle.py
@@ -1,6 +1,6 @@
 import unittest
 from youtube2notion.youtube_subtitle import YoutubeSubtitle
-from youtube_transcript_api._errors import NoTranscriptFound
+from youtube_transcript_api._errors import TranslationLanguageNotAvailable
 
 
 class TestYoutubeSubtitle(unittest.TestCase):
@@ -20,8 +20,8 @@ class TestYoutubeSubtitle(unittest.TestCase):
 
     def test_get_subtitle_with_specific_language(self):
         self.assertIsNotNone(
-            YoutubeSubtitle.get_subtitle_elements(self.video_id, ['ko']))
+            YoutubeSubtitle.get_subtitle_elements(self.video_id, ['ko', 'en']))
 
     def test_get_subtitle_with_unknown_language_exception(self):
-        with self.assertRaises(NoTranscriptFound):
-            YoutubeSubtitle.get_subtitle_elements(self.video_id, ['aa'])
+        with self.assertRaises(TranslationLanguageNotAvailable):
+            YoutubeSubtitle.get_subtitle_elements(self.video_id, ['aa', 'bb'])

--- a/tests/youtube2notion/test_youtube_subtitle.py
+++ b/tests/youtube2notion/test_youtube_subtitle.py
@@ -1,6 +1,6 @@
 import unittest
 from youtube2notion.youtube_subtitle import YoutubeSubtitle
-from youtube_transcript_api._errors import NoTranscriptFound
+from youtube_transcript_api._errors import TranslationLanguageNotAvailable
 
 
 class TestYoutubeSubtitle(unittest.TestCase):
@@ -18,13 +18,18 @@ class TestYoutubeSubtitle(unittest.TestCase):
         self.assertIsNotNone(
             YoutubeSubtitle.get_subtitle_elements(self.video_id))
 
-    def test_get_subtitle_with_specific_language(self):
+    def test_with_manually_created_subtitle(self):
         self.assertIsNotNone(
-            YoutubeSubtitle.get_subtitle_elements(self.video_id, ['ko', 'en']))
-        self.assertIsNotNone(
-            YoutubeSubtitle.get_subtitle_elements(self.video_id,
-                                                  ['aa', 'bb', 'en']))
+            YoutubeSubtitle.get_subtitle_elements('MY5SatbZMAo', ['en']))
 
-    def test_get_subtitle_with_unknown_language_codes_exception(self):
-        with self.assertRaises(NoTranscriptFound):
+    def test_with_auto_generated_subtitle(self):
+        self.assertIsNotNone(
+            YoutubeSubtitle.get_subtitle_elements('5-MXyCr3y5M', ['ko']))
+
+    def test_with_auto_translated_subtitle(self):
+        self.assertIsNotNone(
+            YoutubeSubtitle.get_subtitle_elements('5-MXyCr3y5M', ['en']))
+
+    def test_with_translation_language_not_available_exception(self):
+        with self.assertRaises(TranslationLanguageNotAvailable):
             YoutubeSubtitle.get_subtitle_elements(self.video_id, ['aa', 'bb'])

--- a/youtube2notion.py
+++ b/youtube2notion.py
@@ -20,14 +20,14 @@ def youtube2notion(video_id: str, output_dir, notion_token_v2, notion_page_url,
     click.echo('output_dir: %s' % output_dir)
     click.echo('notion_token_v2: %s' % notion_token_v2)
     click.echo('notion_page_url: %s' % notion_page_url)
-    click.echo('text_language: %s' % text_language)
+    click.echo('subtitle_language: %s' % subtitle_language)
 
     y2n = Youtube2notion(
         video_id=video_id,
         output_dir=output_dir,
         notion_token_v2=notion_token_v2,
         notion_page_url=notion_page_url,
-        text_language=text_language)
+        subtitle_language=subtitle_language)
 
     try:
         y2n.execute()

--- a/youtube2notion.py
+++ b/youtube2notion.py
@@ -10,7 +10,12 @@ import click
 @click.option(
     '--notion-page-url', '-p', 'notion_page_url', required=False, type=str)
 @click.option(
-    '--subtitle_language', '-l', 'subtitle_language', required=False, type=str)
+    '--subtitle_language',
+    '-l',
+    'subtitle_language',
+    required=False,
+    type=str,
+    default='en')
 def youtube2notion(video_id: str, output_dir, notion_token_v2, notion_page_url,
                    subtitle_language):
     if not output_dir:

--- a/youtube2notion.py
+++ b/youtube2notion.py
@@ -10,8 +10,8 @@ import click
 @click.option(
     '--notion-page-url', '-p', 'notion_page_url', required=False, type=str)
 @click.option(
-    '--text_language', '-l', 'text_language', required=False, type=str)
-def youtube2notion(video_id: str, output_dir, notion_token_v2, notion_page_url, text_language):
+    '--subtitle_language', '-l', 'subtitle_language', required=False, type=str)
+def youtube2notion(video_id: str, output_dir, notion_token_v2, notion_page_url, subtitle_language):
     if not output_dir:
         output_dir = './tmp/%s/' % video_id
 

--- a/youtube2notion.py
+++ b/youtube2notion.py
@@ -9,7 +9,9 @@ import click
     '--notion-token-v2', '-t', 'notion_token_v2', required=False, type=str)
 @click.option(
     '--notion-page-url', '-p', 'notion_page_url', required=False, type=str)
-def youtube2notion(video_id: str, output_dir, notion_token_v2, notion_page_url):
+@click.option(
+    '--text_language', '-l', 'text_language', required=False, type=str)
+def youtube2notion(video_id: str, output_dir, notion_token_v2, notion_page_url, text_language):
     if not output_dir:
         output_dir = './tmp/%s/' % video_id
 
@@ -17,12 +19,14 @@ def youtube2notion(video_id: str, output_dir, notion_token_v2, notion_page_url):
     click.echo('output_dir: %s' % output_dir)
     click.echo('notion_token_v2: %s' % notion_token_v2)
     click.echo('notion_page_url: %s' % notion_page_url)
+    click.echo('text_language: %s' % text_language)
 
     y2n = Youtube2notion(
         video_id=video_id,
         output_dir=output_dir,
         notion_token_v2=notion_token_v2,
-        notion_page_url=notion_page_url)
+        notion_page_url=notion_page_url,
+        text_language=text_language)
 
     try:
         y2n.execute()

--- a/youtube2notion.py
+++ b/youtube2notion.py
@@ -11,7 +11,8 @@ import click
     '--notion-page-url', '-p', 'notion_page_url', required=False, type=str)
 @click.option(
     '--subtitle_language', '-l', 'subtitle_language', required=False, type=str)
-def youtube2notion(video_id: str, output_dir, notion_token_v2, notion_page_url, subtitle_language):
+def youtube2notion(video_id: str, output_dir, notion_token_v2, notion_page_url,
+                   subtitle_language):
     if not output_dir:
         output_dir = './tmp/%s/' % video_id
 

--- a/youtube2notion/youtube2notion.py
+++ b/youtube2notion/youtube2notion.py
@@ -15,7 +15,7 @@ class Youtube2notion:
                  output_dir: str = '',
                  notion_token_v2: str = '',
                  notion_page_url: str = '',
-                 text_language: str = 'ko'):
+                 subtitle_language: str = 'ko'):
         self.video_id = video_id
         self.output_dir = output_dir
         self.images_output_dir = self.output_dir + 'images/'
@@ -23,13 +23,13 @@ class Youtube2notion:
         self.notion_token_v2 = notion_token_v2
         self.notion_page_url = notion_page_url
 
-        self.text_language = text_language
+        self.subtitle_language = subtitle_language
 
     def _download_video(self) -> str:
         return YoutubeVideo.download(self.video_id, self.output_dir)
 
     def _get_subtitle_elements(self) -> list[SubtitleElement]:
-        return YoutubeSubtitle.get_subtitle_elements(self.video_id, [self.text_language, 'en'])
+        return YoutubeSubtitle.get_subtitle_elements(self.video_id, [self.subtitle_language, 'en'])
 
     def _take_screenshots(self, input_filename: str):
         Path(self.images_output_dir).mkdir(parents=True, exist_ok=True)
@@ -59,7 +59,7 @@ class Youtube2notion:
         page = client.get_block(notion_page_url)
 
         with open(md_file, 'r', encoding='utf-8') as f:
-            new_page = page.children.add_new(PageBlock, title=self.video_id + '(' + self.text_language + ')')
+            new_page = page.children.add_new(PageBlock, title=self.video_id + '(' + self.subtitle_language + ')')
             upload(f, new_page)
 
     def execute(self):
@@ -69,7 +69,7 @@ class Youtube2notion:
         self._take_screenshots(downloaded_video_filename)
 
         md = self._generage_markdown(
-            title=self.video_id + '(' + self.text_language + ')',
+            title=self.video_id + '(' + self.subtitle_language + ')',
             subtitle_elements=subtitle_elements,
             images_dir='./images/')
 

--- a/youtube2notion/youtube2notion.py
+++ b/youtube2notion/youtube2notion.py
@@ -29,8 +29,8 @@ class Youtube2notion:
         return YoutubeVideo.download(self.video_id, self.output_dir)
 
     def _get_subtitle_elements(self) -> list[SubtitleElement]:
-        return YoutubeSubtitle.get_subtitle_elements(
-            self.video_id, [self.subtitle_language, 'en'])
+        return YoutubeSubtitle.get_subtitle_elements(self.video_id,
+                                                     [self.subtitle_language])
 
     def _take_screenshots(self, input_filename: str):
         Path(self.images_output_dir).mkdir(parents=True, exist_ok=True)

--- a/youtube2notion/youtube2notion.py
+++ b/youtube2notion/youtube2notion.py
@@ -14,7 +14,8 @@ class Youtube2notion:
                  video_id: str,
                  output_dir: str = '',
                  notion_token_v2: str = '',
-                 notion_page_url: str = ''):
+                 notion_page_url: str = '',
+                 text_language: str = 'ko'):
         self.video_id = video_id
         self.output_dir = output_dir
         self.images_output_dir = self.output_dir + 'images/'
@@ -22,11 +23,13 @@ class Youtube2notion:
         self.notion_token_v2 = notion_token_v2
         self.notion_page_url = notion_page_url
 
+        self.text_language = text_language
+
     def _download_video(self) -> str:
         return YoutubeVideo.download(self.video_id, self.output_dir)
 
     def _get_subtitle_elements(self) -> list[SubtitleElement]:
-        return YoutubeSubtitle.get_subtitle_elements(self.video_id)
+        return YoutubeSubtitle.get_subtitle_elements(self.video_id, [self.text_language, 'en'])
 
     def _take_screenshots(self, input_filename: str):
         Path(self.images_output_dir).mkdir(parents=True, exist_ok=True)
@@ -56,7 +59,7 @@ class Youtube2notion:
         page = client.get_block(notion_page_url)
 
         with open(md_file, 'r', encoding='utf-8') as f:
-            new_page = page.children.add_new(PageBlock, title=self.video_id)
+            new_page = page.children.add_new(PageBlock, title=self.video_id + '(' + self.text_language + ')')
             upload(f, new_page)
 
     def execute(self):
@@ -66,7 +69,7 @@ class Youtube2notion:
         self._take_screenshots(downloaded_video_filename)
 
         md = self._generage_markdown(
-            title=self.video_id,
+            title=self.video_id + '(' + self.text_language + ')',
             subtitle_elements=subtitle_elements,
             images_dir='./images/')
 

--- a/youtube2notion/youtube2notion.py
+++ b/youtube2notion/youtube2notion.py
@@ -29,7 +29,8 @@ class Youtube2notion:
         return YoutubeVideo.download(self.video_id, self.output_dir)
 
     def _get_subtitle_elements(self) -> list[SubtitleElement]:
-        return YoutubeSubtitle.get_subtitle_elements(self.video_id, [self.subtitle_language, 'en'])
+        return YoutubeSubtitle.get_subtitle_elements(
+            self.video_id, [self.subtitle_language, 'en'])
 
     def _take_screenshots(self, input_filename: str):
         Path(self.images_output_dir).mkdir(parents=True, exist_ok=True)
@@ -59,7 +60,9 @@ class Youtube2notion:
         page = client.get_block(notion_page_url)
 
         with open(md_file, 'r', encoding='utf-8') as f:
-            new_page = page.children.add_new(PageBlock, title=self.video_id + '(' + self.subtitle_language + ')')
+            new_page = page.children.add_new(
+                PageBlock,
+                title=self.video_id + '(' + self.subtitle_language + ')')
             upload(f, new_page)
 
     def execute(self):

--- a/youtube2notion/youtube_subtitle.py
+++ b/youtube2notion/youtube_subtitle.py
@@ -25,21 +25,21 @@ class SubtitleElement:
 class YoutubeSubtitle:
 
     @classmethod
-    def __fetch_transcript(cls, video_id: str,
-                           language_code_candidates: list) -> list:
+    def __fetch_transcript(cls, video_id: str, language_codes: list) -> list:
         """
-        Returns a fetched transcript from YouTube. It makes the best effort to get a proper transcript following below priorities:
-        1. a manually created transcript prior to a automatically generated one.
-        2. language codes in language_code_candidates param will be traversed in order.
+        Returns a fetched transcript from YouTube. It makes the best effort to
+        get a proper transcript following below priorities:
+        1. a manually created transcript prior to a auto-generated one.
+        2. language codes in language_codes param will be traversed in order.
         """
         transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
 
         try:
             return transcript_list.find_manually_created_transcript(
-                language_code_candidates).fetch()
+                language_codes).fetch()
         except NoTranscriptFound:
             return transcript_list.find_generated_transcript(
-                language_code_candidates).fetch()
+                language_codes).fetch()
 
     @classmethod
     def get_subtitle_elements(

--- a/youtube2notion/youtube_subtitle.py
+++ b/youtube2notion/youtube_subtitle.py
@@ -1,4 +1,5 @@
 from youtube_transcript_api import YouTubeTranscriptApi
+from youtube_transcript_api._errors import NoTranscriptFound
 
 
 class SubtitleElement:
@@ -24,29 +25,32 @@ class SubtitleElement:
 class YoutubeSubtitle:
 
     @classmethod
-    def get_subtitle_elements(cls,
-                              video_id: str,
-                              languages=['ko', 'en']) -> list[SubtitleElement]:
+    def __fetch_transcript(cls, video_id: str,
+                           language_code_candidates: list) -> list:
+        """
+        Returns a fetched transcript from YouTube. It makes the best effort to get a proper transcript following below priorities:
+        1. a manually created transcript prior to a automatically generated one.
+        2. language codes in language_code_candidates param will be traversed in order.
+        """
         transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
-        is_finded = {'first': False, 'second': False}
-        for transcript in transcript_list:
-            if transcript.language_code == languages[0]:
-                is_finded['first'] = True
-                break
-            if transcript.language_code == languages[1]:
-                is_finded['second'] = True
 
-        transcript_result: list[SubtitleElement] = []
-        if is_finded['first']:
-            transcript_result = transcript.fetch()
-        elif is_finded['second']:
-            transcript = transcript_list.find_transcript([languages[1]])
-            transcript_result = transcript.translate(languages[0]).fetch()
-        else:
-            transcript_result = transcript.translate(languages[0]).fetch()
+        try:
+            return transcript_list.find_manually_created_transcript(
+                language_code_candidates).fetch()
+        except NoTranscriptFound:
+            return transcript_list.find_generated_transcript(
+                language_code_candidates).fetch()
+
+    @classmethod
+    def get_subtitle_elements(
+            cls,
+            video_id: str,
+            language_code_candidates=['ko', 'en']) -> list[SubtitleElement]:
+        fetched_transcript = YoutubeSubtitle.__fetch_transcript(
+            video_id, language_code_candidates)
 
         subtitle_elements: list[SubtitleElement] = []
-        for sentence in transcript_result:
+        for sentence in fetched_transcript:
             subtitle_elements.append(
                 SubtitleElement(
                     text=sentence.get('text'),

--- a/youtube2notion/youtube_subtitle.py
+++ b/youtube2notion/youtube_subtitle.py
@@ -27,10 +27,26 @@ class YoutubeSubtitle:
     def get_subtitle_elements(cls,
                               video_id: str,
                               languages=['ko', 'en']) -> list[SubtitleElement]:
-        transcript = YouTubeTranscriptApi().get_transcript(video_id, languages)
+        transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+        is_finded = {'first': False, 'second': False}
+        for transcript in transcript_list:
+            if transcript.language_code == languages[0]:
+                is_finded['first'] = True
+                break
+            if transcript.language_code == languages[1]:
+                is_finded['second'] = True
+
+        transcript_result: list[SubtitleElement] = []
+        if is_finded['first'] == True:
+            transcript_result = transcript.fetch()
+        elif is_finded['second'] == True:
+            transcript = transcript_list.find_transcript([languages[1]])
+            transcript_result = transcript.translate(languages[0]).fetch()
+        else:
+            transcript_result = transcript.translate(languages[0]).fetch()
 
         subtitle_elements: list[SubtitleElement] = []
-        for sentence in transcript:
+        for sentence in transcript_result:
             subtitle_elements.append(
                 SubtitleElement(
                     text=sentence.get('text'),

--- a/youtube2notion/youtube_subtitle.py
+++ b/youtube2notion/youtube_subtitle.py
@@ -25,12 +25,17 @@ class SubtitleElement:
 class YoutubeSubtitle:
 
     @classmethod
-    def __fetch_transcript(cls, video_id: str, language_codes: list) -> list:
+    def __fetch_transcript(cls,
+                           video_id: str,
+                           language_codes: list[str] = ['ko', 'en']) -> list:
         """
         Returns a fetched transcript from YouTube. It makes the best effort to
         get a proper transcript following below priorities:
         1. a manually created transcript prior to a auto-generated one.
         2. language codes in language_codes param will be traversed in order.
+        3. if there is neither created nor generated transcript, it will try to
+        get a auto-translated one by the first language code of
+        language_codes param.
         """
         transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
 
@@ -38,14 +43,24 @@ class YoutubeSubtitle:
             return transcript_list.find_manually_created_transcript(
                 language_codes).fetch()
         except NoTranscriptFound:
+            pass
+
+        try:
             return transcript_list.find_generated_transcript(
                 language_codes).fetch()
+        except NoTranscriptFound:
+            pass
+
+        if transcript_list and language_codes:
+            for transcript in transcript_list:
+                return transcript.translate(language_codes[0]).fetch()
 
     @classmethod
     def get_subtitle_elements(
-            cls,
-            video_id: str,
-            language_code_candidates=['ko', 'en']) -> list[SubtitleElement]:
+        cls,
+        video_id: str,
+        language_code_candidates: list[str] = ['ko', 'en']
+    ) -> list[SubtitleElement]:
         fetched_transcript = YoutubeSubtitle.__fetch_transcript(
             video_id, language_code_candidates)
 

--- a/youtube2notion/youtube_subtitle.py
+++ b/youtube2notion/youtube_subtitle.py
@@ -37,9 +37,9 @@ class YoutubeSubtitle:
                 is_finded['second'] = True
 
         transcript_result: list[SubtitleElement] = []
-        if is_finded['first'] == True:
+        if is_finded['first']:
             transcript_result = transcript.fetch()
-        elif is_finded['second'] == True:
+        elif is_finded['second']:
             transcript = transcript_list.find_transcript([languages[1]])
             transcript_result = transcript.translate(languages[0]).fetch()
         else:


### PR DESCRIPTION
It can be select to text language want to display with the input parameter.

### new input parameter

- text_language `ex) ko, ja, de ...`

### language selection priority

1. Select subtitles of the language of input parameter.
2. If there is no subtitles in the language of the input parameter, translate English subtitles.
3. If there is no subtitles in the language of the input parameter and English subtitles, Translate the automatically translated subtitles to input parameter language.

### notion page title changed

- VIDEO_ID + TEXT_LANGUAGE `ex) EWbGahsxXK4 => EWbGahsxXK4(ko)`